### PR TITLE
Fix use of Null op when completedSteps used in initState

### DIFF
--- a/lib/src/foundation/persistence_provider.dart
+++ b/lib/src/foundation/persistence_provider.dart
@@ -47,7 +47,10 @@ class SharedPreferencesProvider implements PersistenceProvider {
   @override
   Future<Set<String?>> completedSteps(Iterable<String?>? featuresIds) async {
     final prefs = await SharedPreferences.getInstance();
-    return featuresIds!
+    if (featuresIds == null) {
+      return Set();
+    }
+    return featuresIds
         .where((featureId) =>
             prefs.getBool(_normalizeFeatureId(featureId)) == true)
         .toSet();


### PR DESCRIPTION
Fixes occurrence of "Unhandled Exception: Null check operator used on a null value" if `hasPreviouslyCompleted()` is used in the app initState before any steps have run.